### PR TITLE
Changed schema to accept SQL port and Azure subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ To enable monitoring for a specific HANA instance:
 az hanainstance monitor enable \
     --resource-group $RESOURCE_GROUP \
     --instance-name $HANA_INSTANCE_NAME \
-    --hana-vnet $HANA_VNET \
+    --hana-subnet $HANA_SUBNET \
     --hana-hostname $HANA_HOSTNAME \
-    --hana-instance-num $HANA_INSTANCENUM \
+    --hana-db-name $HANA_DB_NAME \
+    --hana-db-sql-port $HANA_DB_SQL_PORT \
     --hana-db-username $HANA_DB_USERNAME \
     --hana-db-password $HANA_DB_PW
 ```

--- a/azext_hanaonazure/_params.py
+++ b/azext_hanaonazure/_params.py
@@ -14,16 +14,14 @@ def load_arguments(self, _):
         c.argument('instance_name', options_list=[
                    '--instance-name', '-n'], help="The name of the SAP HANA instance", id_part='name')
     with self.argument_context('hanainstance monitor') as c:
-        c.argument('hana_vnet', options_list=[
-                   '--hana-vnet', '-hv'], help="ARM ID of an Azure Vnet with access to the HANA instance.")
+        c.argument('hana_subnet', options_list=[
+                   '--hana-subnet'], help="ARM ID of an Azure Subnet with access to the HANA instance.")
         c.argument('hana_hostname', options_list=[
                    '--hana-hostname'], help="Hostname of the HANA Instance blade.")
-        c.argument('hana_instance_num', options_list=[
-                   '--hana-instance-num'], help="A number between 00 and 99")
-        c.argument('use_mdc', options_list=[
-                   '--use-mdc'], help="A boolean to determine the use of Multiple Database Containers")
-        c.argument('hana_database', options_list=[
-                   '--hana-database', '-hdb'], help="Name of the database itself.  It only needs to be specified if using MDC")
+        c.argument('hana_db_name', options_list=[
+                   '--hana-db-name', '-hdb'], help="Name of the database itself.")
+        c.argument('hana_db_sql_port', options_list=[
+                   '--hana-db-sql-port'], help="The port number of the tenant DB. Used to connect to the DB.")
         c.argument('hana_db_username', options_list=[
                    '--hana-db-username'], help="Username for the HANA database to login to for monitoring")
         c.argument('hana_db_password', options_list=[

--- a/azext_hanaonazure/custom.py
+++ b/azext_hanaonazure/custom.py
@@ -30,15 +30,12 @@ def update_hanainstance(client, resource_group_name, instance_name, **kwargs):
     return client.update(resource_group_name, instance_name, kwargs['parameters'].tags)
 
 
-def enable_monitoring_hanainstance(client, resource_group_name, instance_name, hana_vnet, hana_hostname, hana_instance_num, hana_db_username, hana_db_password, hana_mdc=True, hana_database=""):
+def enable_monitoring_hanainstance(client, resource_group_name, instance_name, hana_subnet, hana_hostname, hana_db_sql_port, hana_db_username, hana_db_password, hana_db_name=""):
     monitoring_details = {
-        "hanaInstanceNum": hana_instance_num,
-        "hanaVnet": hana_vnet,
+        "hanaSubnet": hana_subnet,
         "hanaHostname": hana_hostname,
+        "hanaDbSqlPort": hana_db_sql_port,
         "hanaDbUsername": hana_db_username,
-        "hanaDbPassword": hana_db_password,
-        "dbContainer": "multiple" if hana_mdc else "single"
+        "hanaDbPassword": hana_db_password
     }
-    if hana_database is not None:
-        monitoring_details['hanaDatabase'] = hana_database
     return client.enable_monitoring(resource_group_name, instance_name, monitoring_details)

--- a/azext_hanaonazure/modules_sdk/models/__init__.py
+++ b/azext_hanaonazure/modules_sdk/models/__init__.py
@@ -43,7 +43,6 @@ from .hana_management_client_enums import (
     HanaHardwareTypeNamesEnum,
     HanaInstanceSizeNamesEnum,
     HanaInstancePowerStateEnum,
-    HanaDatabaseContainersEnum,
 )
 
 __all__ = [
@@ -65,5 +64,4 @@ __all__ = [
     'HanaHardwareTypeNamesEnum',
     'HanaInstanceSizeNamesEnum',
     'HanaInstancePowerStateEnum',
-    'HanaDatabaseContainersEnum',
 ]

--- a/azext_hanaonazure/modules_sdk/models/hana_management_client_enums.py
+++ b/azext_hanaonazure/modules_sdk/models/hana_management_client_enums.py
@@ -48,9 +48,3 @@ class HanaInstancePowerStateEnum(str, Enum):
     stopped = "stopped"
     restarting = "restarting"
     unknown = "unknown"
-
-
-class HanaDatabaseContainersEnum(str, Enum):
-
-    single = "single"
-    multiple = "multiple"

--- a/azext_hanaonazure/modules_sdk/models/monitoring_details.py
+++ b/azext_hanaonazure/modules_sdk/models/monitoring_details.py
@@ -15,22 +15,16 @@ from msrest.serialization import Model
 class MonitoringDetails(Model):
     """Details needed to monitor a Hana Instance.
 
-    :param hana_vnet: ARM ID of an Azure Vnet with access to the HANA
+    :param hana_subnet: ARM ID of an Azure Subnet with access to the HANA
      instance.
-    :type hana_vnet: str
+    :type hana_subnet: str
     :param hana_hostname: Hostname of the HANA Instance blade.
     :type hana_hostname: str
-    :param hana_instance_num: A number between 00 and 99, stored as a string
-     to maintain leading zero.
-    :type hana_instance_num: str
-    :param db_container: Either single or multiple depending on the use of
-     MDC(Multiple Database Containers). Possible values include: 'single',
-     'multiple'. Default value: "single" .
-    :type db_container: str or
-     ~azure.mgmt.hanaonazure.models.HanaDatabaseContainersEnum
-    :param hana_database: Name of the database itself.  It only needs to be
-     specified if using MDC
-    :type hana_database: str
+    :param hana_db_name: Name of the database itself.
+    :type hana_db_name: str
+    :param hana_db_sql_port: The port number of the tenant DB. Used to connect
+     to the DB.
+    :type hana_db_sql_port: int
     :param hana_db_username: Username for the HANA database to login to for
      monitoring
     :type hana_db_username: str
@@ -40,21 +34,19 @@ class MonitoringDetails(Model):
     """
 
     _attribute_map = {
-        'hana_vnet': {'key': 'hanaVnet', 'type': 'str'},
+        'hana_subnet': {'key': 'hanaSubnet', 'type': 'str'},
         'hana_hostname': {'key': 'hanaHostname', 'type': 'str'},
-        'hana_instance_num': {'key': 'hanaInstanceNum', 'type': 'str'},
-        'db_container': {'key': 'dbContainer', 'type': 'str'},
-        'hana_database': {'key': 'hanaDatabase', 'type': 'str'},
+        'hana_db_name': {'key': 'hanaDbName', 'type': 'str'},
+        'hana_db_sql_port': {'key': 'hanaDbSqlPort', 'type': 'int'},
         'hana_db_username': {'key': 'hanaDbUsername', 'type': 'str'},
         'hana_db_password': {'key': 'hanaDbPassword', 'type': 'str'},
     }
 
     def __init__(self, **kwargs):
         super(MonitoringDetails, self).__init__(**kwargs)
-        self.hana_vnet = kwargs.get('hana_vnet', None)
+        self.hana_subnet = kwargs.get('hana_subnet', None)
         self.hana_hostname = kwargs.get('hana_hostname', None)
-        self.hana_instance_num = kwargs.get('hana_instance_num', None)
-        self.db_container = kwargs.get('db_container', "single")
-        self.hana_database = kwargs.get('hana_database', None)
+        self.hana_db_name = kwargs.get('hana_db_name', None)
+        self.hana_db_sql_port = kwargs.get('hana_db_sql_port', None)
         self.hana_db_username = kwargs.get('hana_db_username', None)
         self.hana_db_password = kwargs.get('hana_db_password', None)

--- a/azext_hanaonazure/modules_sdk/models/monitoring_details_py3.py
+++ b/azext_hanaonazure/modules_sdk/models/monitoring_details_py3.py
@@ -15,22 +15,16 @@ from msrest.serialization import Model
 class MonitoringDetails(Model):
     """Details needed to monitor a Hana Instance.
 
-    :param hana_vnet: ARM ID of an Azure Vnet with access to the HANA
+    :param hana_subnet: ARM ID of an Azure Subnet with access to the HANA
      instance.
-    :type hana_vnet: str
+    :type hana_subnet: str
     :param hana_hostname: Hostname of the HANA Instance blade.
     :type hana_hostname: str
-    :param hana_instance_num: A number between 00 and 99, stored as a string
-     to maintain leading zero.
-    :type hana_instance_num: str
-    :param db_container: Either single or multiple depending on the use of
-     MDC(Multiple Database Containers). Possible values include: 'single',
-     'multiple'. Default value: "single" .
-    :type db_container: str or
-     ~azure.mgmt.hanaonazure.models.HanaDatabaseContainersEnum
-    :param hana_database: Name of the database itself.  It only needs to be
-     specified if using MDC
-    :type hana_database: str
+    :param hana_db_name: Name of the database itself.
+    :type hana_db_name: str
+    :param hana_db_sql_port: The port number of the tenant DB. Used to connect
+     to the DB.
+    :type hana_db_sql_port: int
     :param hana_db_username: Username for the HANA database to login to for
      monitoring
     :type hana_db_username: str
@@ -40,21 +34,19 @@ class MonitoringDetails(Model):
     """
 
     _attribute_map = {
-        'hana_vnet': {'key': 'hanaVnet', 'type': 'str'},
+        'hana_subnet': {'key': 'hanaSubnet', 'type': 'str'},
         'hana_hostname': {'key': 'hanaHostname', 'type': 'str'},
-        'hana_instance_num': {'key': 'hanaInstanceNum', 'type': 'str'},
-        'db_container': {'key': 'dbContainer', 'type': 'str'},
-        'hana_database': {'key': 'hanaDatabase', 'type': 'str'},
+        'hana_db_name': {'key': 'hanaDbName', 'type': 'str'},
+        'hana_db_sql_port': {'key': 'hanaDbSqlPort', 'type': 'int'},
         'hana_db_username': {'key': 'hanaDbUsername', 'type': 'str'},
         'hana_db_password': {'key': 'hanaDbPassword', 'type': 'str'},
     }
 
-    def __init__(self, *, hana_vnet: str=None, hana_hostname: str=None, hana_instance_num: str=None, db_container="single", hana_database: str=None, hana_db_username: str=None, hana_db_password: str=None, **kwargs) -> None:
+    def __init__(self, *, hana_subnet: str=None, hana_hostname: str=None, hana_db_name: str=None, hana_db_sql_port: int=None, hana_db_username: str=None, hana_db_password: str=None, **kwargs) -> None:
         super(MonitoringDetails, self).__init__(**kwargs)
-        self.hana_vnet = hana_vnet
+        self.hana_subnet = hana_subnet
         self.hana_hostname = hana_hostname
-        self.hana_instance_num = hana_instance_num
-        self.db_container = db_container
-        self.hana_database = hana_database
+        self.hana_db_name = hana_db_name
+        self.hana_db_sql_port = hana_db_sql_port
         self.hana_db_username = hana_db_username
         self.hana_db_password = hana_db_password


### PR DESCRIPTION
Updated the commands to reflect the changes in the schema.
The first change is that the schema now accepts a subnet instead of a vnet.
The second change is the information that is needed to connect to the database.  After Tobias' CAYL project, we decided to accept a SQL port instead of the SAP instance num because the port is a more accurate way to achieve connection to the database.