### PR TITLE
Set max CLI core version to avoid breaking change in 2.0.67

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.3.8 (2019-06-12)
+++++++++++++++++++
+
+- Set the maximum CLI core version to avoid breaking change in CLI core version 2.0.67
+
 0.3.7 (2019-05-23)
 ++++++++++++++++++
 

--- a/azext_hanaonazure/azext_metadata.json
+++ b/azext_hanaonazure/azext_metadata.json
@@ -1,4 +1,5 @@
 {
+  "azext.maxCliCoreVersion": "2.0.66",
   "azext.minCliCoreVersion": "2.0.46",
-  "version": "0.3.7"
+  "version": "0.3.8"
 }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.3.7"
+VERSION = "0.3.8"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
I will send a following change to remove the conflicting code from our repo (after verifying we do not use it) and set the new version of the CLI core to be supported.