### PR TITLE
Remove use of min_profile to comply with CLI core version 2.0.67

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.3.9 (2019-06-14)
+++++++++++++++++++
+
+- Remove use of min_profile to comply with CLI core version 2.0.67
+
 0.3.8 (2019-06-12)
 ++++++++++++++++++
 

--- a/azext_hanaonazure/__init__.py
+++ b/azext_hanaonazure/__init__.py
@@ -13,8 +13,7 @@ class HanaInstanceCommandsLoader(AzCommandsLoader):
         from azure.cli.core.commands import CliCommandType
         custom_type = CliCommandType(operations_tmpl='azext_hanaonazure.custom#{}')
         super(HanaInstanceCommandsLoader, self).__init__(cli_ctx=cli_ctx,
-                                                      custom_command_type=custom_type,
-                                                      min_profile='2017-03-10-profile')
+                                                         custom_command_type=custom_type)
 
     def load_command_table(self, args):
         from azext_hanaonazure.commands import load_command_table

--- a/azext_hanaonazure/azext_metadata.json
+++ b/azext_hanaonazure/azext_metadata.json
@@ -1,5 +1,4 @@
 {
-  "azext.maxCliCoreVersion": "2.0.66",
   "azext.minCliCoreVersion": "2.0.46",
-  "version": "0.3.8"
+  "version": "0.3.9"
 }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.3.8"
+VERSION = "0.3.9"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
See https://msazure.visualstudio.com/DefaultCollection/One/_workitems/edit/4777087 for context; CLI core version 2.0.67 does not support `min_profile`, so we must remove our use of it to comply with newer versions of CLI core.