### PR TITLE
Add ability to Patch an SapMonitor to add tags

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.5.5 (2019-09-04)
+++++++++++++++++++
+
+- Added Update method for SapMonitor, which will allow adding tags
+
 0.5.4 (2019-08-08)
 ++++++++++++++++++
 

--- a/azext_hanaonazure/_help.py
+++ b/azext_hanaonazure/_help.py
@@ -76,3 +76,7 @@ helps['sapmonitor delete'] = """
     type: command
     short-summary: Delete a SAP Monitor.
 """
+helps['sapmonitor update'] = """
+    type: command
+    short-summary: Updates the tags field of a SAP Monitor.
+"""

--- a/azext_hanaonazure/azext_metadata.json
+++ b/azext_hanaonazure/azext_metadata.json
@@ -1,4 +1,4 @@
 {
   "azext.minCliCoreVersion": "2.0.46",
-  "version": "0.5.1"
+  "version": "0.5.5"
 }

--- a/azext_hanaonazure/commands.py
+++ b/azext_hanaonazure/commands.py
@@ -29,4 +29,6 @@ def load_command_table(self, _):
         g.custom_command('list', 'list_sapmonitor')
         g.custom_command('show', 'show_sapmonitor', exception_handler=empty_on_404)
         g.custom_command('create', 'create_sapmonitor')
+        g.generic_update_command('update', getter_name='show_sapmonitor', setter_name='update_sapmonitor',
+                                 command_type=custom_type, supports_no_wait=True)
         g.custom_command('delete', 'delete_sapmonitor')

--- a/azext_hanaonazure/custom.py
+++ b/azext_hanaonazure/custom.py
@@ -196,6 +196,9 @@ def delete_sapmonitor(cmd, client, resource_group_name, monitor_name):
 
     return client.delete(resource_group_name, monitor_name)
 
+def update_sapmonitor(client, resource_group_name, monitor_name, **kwargs):
+    return client.update(resource_group_name, monitor_name, kwargs['parameters'].tags)
+
 def get_csi_name(subscription_id, resource_group, resource_name):
     arm_resource_id = arm_resource_id_format.format(subscription_id, resource_group, resource_name)
     return 'sapmon-csi-{}'.format(hash(arm_resource_id))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.5.4"
+VERSION = "0.5.5"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
Since we now have the PATCH API in the RP, we add the `az sapmonitor update` command, which will enable a user to add tags to their sapmonitor resource