### PR TITLE
  add option to use existing log analytics workspace

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.5.8 (2019-11-26)
+++++++++++++++++++
+
+- Added --log-analytics-workspace-arm-id to allow using existing log analytics workspace for SAP Monitor
+
 0.5.7 (2019-11-22)
 ++++++++++++++++++
 

--- a/azext_hanaonazure/_client_factory.py
+++ b/azext_hanaonazure/_client_factory.py
@@ -21,10 +21,10 @@ def _keyvault_client_factory(cli_ctx, subscription_id=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(cli_ctx, KeyVaultManagementClient, subscription_id=subscription_id)
 
-def _loganalytics_client_factory(cli_ctx, subsription_id=None):
+def _loganalytics_client_factory(cli_ctx, subscription_id=None):
     from azure.mgmt.loganalytics.operations import WorkspacesOperations
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, WorkspacesOperations, subsription_id=subsription_id)
+    return get_mgmt_service_client(cli_ctx, WorkspacesOperations, subscription_id=subscription_id)
 
 def cf_sapmonitor_groups(cli_ctx, *_):
     return _hana_instance_client_factory(cli_ctx).sap_monitors

--- a/azext_hanaonazure/_client_factory.py
+++ b/azext_hanaonazure/_client_factory.py
@@ -21,7 +21,7 @@ def _keyvault_client_factory(cli_ctx, subscription_id=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(cli_ctx, KeyVaultManagementClient, subscription_id=subscription_id)
 
-def _loganalytics_client_factory(cli_ctx, subsription_id=None):
+def _loganalytics_client_factory(cli_ctx, subscription_id=None):
     from azure.mgmt.loganalytics import LogAnalyticsManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(cli_ctx, LogAnalyticsManagementClient, subscription_id=subscription_id)

--- a/azext_hanaonazure/_client_factory.py
+++ b/azext_hanaonazure/_client_factory.py
@@ -21,5 +21,10 @@ def _keyvault_client_factory(cli_ctx, subscription_id=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(cli_ctx, KeyVaultManagementClient, subscription_id=subscription_id)
 
+def _loganalytics_client_factory(cli_ctx, subsription_id=None):
+    from azure.mgmt.loganalytics.operations import WorkspacesOperations
+    from azure.cli.core.commands.client_factory import get_mgmt_service_client
+    return get_mgmt_service_client(cli_ctx, WorkspacesOperations, subsription_id=subsription_id)
+
 def cf_sapmonitor_groups(cli_ctx, *_):
     return _hana_instance_client_factory(cli_ctx).sap_monitors

--- a/azext_hanaonazure/_client_factory.py
+++ b/azext_hanaonazure/_client_factory.py
@@ -21,10 +21,10 @@ def _keyvault_client_factory(cli_ctx, subscription_id=None):
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
     return get_mgmt_service_client(cli_ctx, KeyVaultManagementClient, subscription_id=subscription_id)
 
-def _loganalytics_client_factory(cli_ctx, subscription_id=None):
-    from azure.mgmt.loganalytics.operations import WorkspacesOperations
+def _loganalytics_client_factory(cli_ctx, subsription_id=None):
+    from azure.mgmt.loganalytics import LogAnalyticsManagementClient
     from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, WorkspacesOperations, subscription_id=subscription_id)
+    return get_mgmt_service_client(cli_ctx, LogAnalyticsManagementClient, subscription_id=subscription_id)
 
 def cf_sapmonitor_groups(cli_ctx, *_):
     return _hana_instance_client_factory(cli_ctx).sap_monitors

--- a/azext_hanaonazure/_params.py
+++ b/azext_hanaonazure/_params.py
@@ -49,3 +49,5 @@ def load_arguments(self, _):
             '--key-vault-id', '--kvi'], help="Key Vault ID containing the HANA credentials")
         c.argument('disable_customer_analytics', options_list=[
             '--disable_customer_analytics', '--dca'], help="Disable sending analytics to Microsoft")
+        c.argument('log_analytics_workspace_arm_id', options_list=[
+            '--log-analytics-workspace-arm-id', '--lawsid'], help="Existing log analytics workspace id to use for log monitoring")

--- a/azext_hanaonazure/azext_metadata.json
+++ b/azext_hanaonazure/azext_metadata.json
@@ -1,4 +1,4 @@
 {
   "azext.minCliCoreVersion": "2.0.46",
-  "version": "0.5.7"
+  "version": "0.5.8"
 }

--- a/azext_hanaonazure/custom.py
+++ b/azext_hanaonazure/custom.py
@@ -168,8 +168,8 @@ def create_sapmonitor(
         loganalytics_resource_group = match.group(2)
         loganalytics_resource_name = match.group(3)
         workspaceClient = _loganalytics_client_factory(cmd.cli_ctx,loganalytics_subscription_id)
-        workspaceObj = workspaceClient.operations.get(loganalytics_resource_group, loganalytics_resource_name)
-        workspaceSharedkey = workspaceClient.operations.get_shared_keys(loganalytics_resource_group, loganalytics_resource_name)
+        workspaceObj = workspaceClient.workspaces.get(loganalytics_resource_group, loganalytics_resource_name)
+        workspaceSharedkey = workspaceClient.workspaces.get_shared_keys(loganalytics_resource_group, loganalytics_resource_name)
 
         monitoring_details.update({
             "logAnalyticsWorkspaceArmId": log_analytics_workspace_arm_id,

--- a/azext_hanaonazure/custom.py
+++ b/azext_hanaonazure/custom.py
@@ -10,6 +10,7 @@ import re
 keyvault_id_format = '/subscriptions/([\w\d-]+)/resourceGroups/([\w\d-]+)/providers/Microsoft.KeyVault/vaults/([\w\d-]+)'
 msi_id_format = '/subscriptions/([\w\d-]+)/resourcegroups/([\w\d-]+)/providers/Microsoft.ManagedIdentity/userAssignedIdentities/([\w\d-]+)'
 arm_resource_id_format = '/subscriptions/{}/resourceGroups/{}/providers/Microsoft.HanaOnAzure/sapMonitors/{}'
+loganalytics_arm_id_format = '/subscriptions/([\w\d-]+)/resourceGroups/([\w\d-]+)/providers/Microsoft.OperationalInsights/workspaces/([\w\d-]+)'
 
 def create_hanainstance(client, location, resource_group_name, instance_name, partner_node_id, ssh_public_key, os_computer_name, ip_address):
     try:
@@ -99,7 +100,8 @@ def create_sapmonitor(
         hana_db_password=None,
         hana_db_password_key_vault_url=None,
         key_vault_id=None,
-        disable_customer_analytics=False):
+        disable_customer_analytics=False,
+        log_analytics_workspace_arm_id=None):
 
     monitoring_details = {
         "location": region,
@@ -142,12 +144,36 @@ def create_sapmonitor(
         accessPolicyEntries = [AccessPolicyEntry(tenant_id=kv.properties.tenant_id, object_id=csi.principal_id, permissions=Permissions(secrets=secretPermissions))]
         properties = VaultAccessPolicyProperties(access_policies=accessPolicyEntries)
         kv_client.vaults.update_access_policy(kv_resource_group,kv_resource_name, 'add', properties)
-
         monitoring_details.update({
             "hanaDbPasswordKeyVaultUrl": hana_db_password_key_vault_url,
             "hanaDbCredentialsMsiId": csi.id,
-            "keyVaultId": key_vault_id,
+            "keyVaultId": key_vault_id
         })
+
+        # Retrieve the log analytics workspace ID and shared key
+        if log_analytics_workspace_arm_id is not None:
+            # Log analytics workspace arm ID has been provided
+            from ._client_factory import _loganalytics_client_factory
+            from azure.mgmt.loganalytics.log_analytics_management_client import LogAnalyticsManagementClient
+
+            # Extract Log analytics workspace information
+            match = re.search(loganalytics_arm_id_format, log_analytics_workspace_arm_id)
+            if not match:
+                raise ValueError("Log Analytics workspace ARM ID is of incorrect format. The format starts with /subscriptions")
+
+            loganalytics_subscription_id = match.group(1)
+            loganalytics_resource_group = match.group(2)
+            loganalytics_resource_name = match.group(3)
+            workspaceClient = _loganalytics_client_factory(cmd.cli_ctx,loganalytics_subscription_id)
+            workspaceObj = workspaceClient.get(loganalytics_resource_group, loganalytics_resource_name)
+            workspaceSharedkey = workspaceClient.get_shared_keys(loganalytics_resource_group, loganalytics_resource_name)
+
+            monitoring_details.update({
+                "logAnalyticsWorkspaceArmId": log_analytics_workspace_arm_id,
+                "logAnalyticsWorkspaceId": workspaceObj.customer_id,
+                "logAnalyticsWorkspaceSharedKey": workspaceSharedkey.primary_shared_key
+            })
+
     else:
         raise ValueError("Either --hana-db-password or both --hana-db-password-key-vault-url and --key-vault-id.")
 

--- a/azext_hanaonazure/custom.py
+++ b/azext_hanaonazure/custom.py
@@ -150,32 +150,32 @@ def create_sapmonitor(
             "keyVaultId": key_vault_id
         })
 
-        # Retrieve the log analytics workspace ID and shared key
-        if log_analytics_workspace_arm_id is not None:
-            # Log analytics workspace arm ID has been provided
-            from ._client_factory import _loganalytics_client_factory
-            from azure.mgmt.loganalytics.log_analytics_management_client import LogAnalyticsManagementClient
-
-            # Extract Log analytics workspace information
-            match = re.search(loganalytics_arm_id_format, log_analytics_workspace_arm_id)
-            if not match:
-                raise ValueError("Log Analytics workspace ARM ID is of incorrect format. The format starts with /subscriptions")
-
-            loganalytics_subscription_id = match.group(1)
-            loganalytics_resource_group = match.group(2)
-            loganalytics_resource_name = match.group(3)
-            workspaceClient = _loganalytics_client_factory(cmd.cli_ctx,loganalytics_subscription_id)
-            workspaceObj = workspaceClient.get(loganalytics_resource_group, loganalytics_resource_name)
-            workspaceSharedkey = workspaceClient.get_shared_keys(loganalytics_resource_group, loganalytics_resource_name)
-
-            monitoring_details.update({
-                "logAnalyticsWorkspaceArmId": log_analytics_workspace_arm_id,
-                "logAnalyticsWorkspaceId": workspaceObj.customer_id,
-                "logAnalyticsWorkspaceSharedKey": workspaceSharedkey.primary_shared_key
-            })
-
     else:
         raise ValueError("Either --hana-db-password or both --hana-db-password-key-vault-url and --key-vault-id.")
+
+    # Retrieve the log analytics workspace ID and shared key
+    if log_analytics_workspace_arm_id is not None:
+        # Log analytics workspace arm ID has been provided
+        from ._client_factory import _loganalytics_client_factory
+        from azure.mgmt.loganalytics.log_analytics_management_client import LogAnalyticsManagementClient
+
+        # Extract Log analytics workspace information
+        match = re.search(loganalytics_arm_id_format, log_analytics_workspace_arm_id)
+        if not match:
+            raise ValueError("Log Analytics workspace ARM ID is of incorrect format. The format starts with /subscriptions")
+
+        loganalytics_subscription_id = match.group(1)
+        loganalytics_resource_group = match.group(2)
+        loganalytics_resource_name = match.group(3)
+        workspaceClient = _loganalytics_client_factory(cmd.cli_ctx,loganalytics_subscription_id)
+        workspaceObj = workspaceClient.get(loganalytics_resource_group, loganalytics_resource_name)
+        workspaceSharedkey = workspaceClient.get_shared_keys(loganalytics_resource_group, loganalytics_resource_name)
+
+        monitoring_details.update({
+            "logAnalyticsWorkspaceArmId": log_analytics_workspace_arm_id,
+            "logAnalyticsWorkspaceId": workspaceObj.customer_id,
+            "logAnalyticsWorkspaceSharedKey": workspaceSharedkey.primary_shared_key
+        })
 
     return client.create(resource_group_name, monitor_name, monitoring_details)
 

--- a/azext_hanaonazure/custom.py
+++ b/azext_hanaonazure/custom.py
@@ -168,8 +168,8 @@ def create_sapmonitor(
         loganalytics_resource_group = match.group(2)
         loganalytics_resource_name = match.group(3)
         workspaceClient = _loganalytics_client_factory(cmd.cli_ctx,loganalytics_subscription_id)
-        workspaceObj = workspaceClient.get(loganalytics_resource_group, loganalytics_resource_name)
-        workspaceSharedkey = workspaceClient.get_shared_keys(loganalytics_resource_group, loganalytics_resource_name)
+        workspaceObj = workspaceClient.operations.get(loganalytics_resource_group, loganalytics_resource_name)
+        workspaceSharedkey = workspaceClient.operations.get_shared_keys(loganalytics_resource_group, loganalytics_resource_name)
 
         monitoring_details.update({
             "logAnalyticsWorkspaceArmId": log_analytics_workspace_arm_id,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.5.7"
+VERSION = "0.5.8"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
This PR adds --log-analytics-workspace-arm-id option to allow the user to use existing log analytics workspace.

Example command:

`az sapmonitor create --resource-group persiaportalsaprg --subscription XX --monitor-name XX --region southeastasia --hana-subnet <...> --hana-hostname <...> --hana-db-sql-port <..>--hana-db-username <..>--hana-db-password <..>--hana-db-name <..> --log-analytics-workspace-arm-id<..>`