### PR TITLE
Create provider instance using Key Vault will no longer pass hanaDbCredentialsMsiId to the API request

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+0.6.4 (2020-06-17)
+++++++++++++++++++
+
+- Create provider instance using Key Vault will no longer pass hanaDbCredentialsMsiId to the API request
+
 0.6.3 (2020-06-02)
 ++++++++++++++++++
 

--- a/azext_hanaonazure/custom.py
+++ b/azext_hanaonazure/custom.py
@@ -336,9 +336,6 @@ def create_providerinstance(
             access_policy_entries = [AccessPolicyEntry(tenant_id=kv.properties.tenant_id, object_id=msi.principal_id, permissions=Permissions(secrets=secret_permissions))]
             vault_access_policy_properties = VaultAccessPolicyProperties(access_policies=access_policy_entries)
             kv_client.vaults.update_access_policy(kv_resource_group,kv_resource_name, 'add', vault_access_policy_properties)
-            properties_json.update({
-                "hanaDbCredentialsMsiId": msi.id,
-            })
         elif 'hanaDbPassword' not in properties_json:
             raise ValueError("Either hanaDbPassword or both hanaDbPasswordKeyVaultUrl and keyVaultId.")
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup, find_packages
 
-VERSION = "0.6.3"
+VERSION = "0.6.4"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
The MSI ID is no longer needed since there is only one MSI (the one created in the managed resource group)