### PR TITLE
Use custom_show_command instead as per guidelines

### DIFF
--- a/azext_hanaonazure/commands.py
+++ b/azext_hanaonazure/commands.py
@@ -16,8 +16,7 @@ def load_command_table(self, _):
     with self.command_group('hanainstance', client_factory=cf_hanainstance_groups) as g:
         g.custom_command('create', 'create_hanainstance')
         g.custom_command('list', 'list_hanainstance')
-        g.custom_command('show', 'show_hanainstance',
-                         exception_handler=empty_on_404)
+        g.custom_show_command('show', 'show_hanainstance')
         g.custom_command('restart', 'restart_hanainstance')
         g.custom_command('start', 'start_hanainstance')
         g.custom_command('shutdown', 'shutdown_hanainstance')
@@ -27,7 +26,7 @@ def load_command_table(self, _):
 
     with self.command_group('sapmonitor', client_factory=cf_sapmonitor_groups) as g:
         g.custom_command('list', 'list_sapmonitor')
-        g.custom_command('show', 'show_sapmonitor', exception_handler=empty_on_404)
+        g.custom_show_command('show', 'show_sapmonitor')
         g.custom_command('create', 'create_sapmonitor')
         g.generic_update_command('update', getter_name='show_sapmonitor', setter_name='update_sapmonitor',
                                  command_type=custom_type, supports_no_wait=True)


### PR DESCRIPTION
Need to update command file to use `custom_show_command` as per [guidelines](https://github.com/Azure/azure-cli/blob/373edd533933e2d115bb8eecab38642db4aea2e0/doc/command_guidelines.md#standard-command-types)